### PR TITLE
Downloaded terraform providers can't be executed on windows (#71)

### DIFF
--- a/provision/internal/operator/terraform/gardener.go
+++ b/provision/internal/operator/terraform/gardener.go
@@ -29,6 +29,12 @@ func initGardenerProvider() error {
 
 	// check if plugin is in the plugins dir
 	if _, err := os.Stat(providerPath); !os.IsNotExist(err) {
+		if runtime.GOOS == "windows" {
+			err = generateWindowsBinary(providerPath)
+			if err != nil {
+				return err
+			}
+		}
 		return nil
 	}
 
@@ -55,6 +61,26 @@ func initGardenerProvider() error {
 		return err
 	}
 
+	if runtime.GOOS == "windows" {
+		// Create exe for windows if it doesn't exist
+		err = generateWindowsBinary(providerPath)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func generateWindowsBinary(providerPath string) error {
+	windowsProviderPath := providerPath + ".exe"
+	if _, err := os.Stat(windowsProviderPath); os.IsNotExist(err) {
+		providerFile, err := ioutil.ReadFile(providerPath)
+		err = ioutil.WriteFile(windowsProviderPath, providerFile, 0700)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
* Restructuring repo - Moving provisioning inside a folder - https://github.com/kyma-incubator/hydroform/issues/34

* Restructuring repo - Moving provisioning inside a folder - https://github.com/kyma-incubator/hydroform/issues/34

* Updating Readme

* Updating go mod

* Updating build-commit.sh file

* Fixing example errors

* Moving install build first

* Fixing test error

* Making file executable

* Provision runs before install

* Updating README for provision module

* Updating readme

* Updating readme

* Updating readme

* Update README.md

* Update README.md

* Updating readme

* Updating readme

* Updating readme

* Updating readme

* Updating readme

* Adding back tag for go.mod

* Updating makefile - Adding individual tests for each module

* Update README.md

* Merge branch 'master' of https://github.com/kyma-incubator/hydroform

# Conflicts:
#	README.md
#	hydroform.go
#	provision/README.md
#	provision/hydroform.go
#	provision/provision.go

* Hydroform custom data path not working on windows

* Downloaded terraform providers can't be executed on windows

* Reverting change

* Downloaded terraform providers can't be executed on windows

* Downloaded terraform providers can't be executed on windows

* fixing fmt error

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
